### PR TITLE
Change target framework from 4 to 3.5

### DIFF
--- a/SimpleWifi/ProfileXML/WPA-Enterprise-PEAP-MSCHAPv2.xml
+++ b/SimpleWifi/ProfileXML/WPA-Enterprise-PEAP-MSCHAPv2.xml
@@ -7,7 +7,7 @@
 		</SSID>
 	</SSIDConfig>
 	<connectionType>ESS</connectionType>
-	<connectionMode>auto</connectionMode>
+	<connectionMode>manual</connectionMode>
 	<MSM>
 		<security>
 			<authEncryption>

--- a/SimpleWifi/ProfileXML/WPA-Enterprise-TLS.xml
+++ b/SimpleWifi/ProfileXML/WPA-Enterprise-TLS.xml
@@ -8,7 +8,7 @@
 		<nonBroadcast>false</nonBroadcast>
 	</SSIDConfig>
 	<connectionType>ESS</connectionType>
-	<connectionMode>auto</connectionMode>
+	<connectionMode>manual</connectionMode>
 	<autoSwitch>false</autoSwitch>
 	<MSM>
 		<security>

--- a/SimpleWifi/ProfileXML/WPA-PSK.xml
+++ b/SimpleWifi/ProfileXML/WPA-PSK.xml
@@ -7,7 +7,7 @@
 		</SSID>
 	</SSIDConfig>
 	<connectionType>ESS</connectionType>
-	<connectionMode>auto</connectionMode>
+	<connectionMode>manual</connectionMode>
 	<autoSwitch>false</autoSwitch>
 	<MSM>
 		<security>

--- a/SimpleWifi/ProfileXML/WPA2-Enterprise-PEAP-MSCHAPv2.xml
+++ b/SimpleWifi/ProfileXML/WPA2-Enterprise-PEAP-MSCHAPv2.xml
@@ -7,7 +7,7 @@
 		</SSID>
 	</SSIDConfig>
 	<connectionType>ESS</connectionType>
-	<connectionMode>auto</connectionMode>
+	<connectionMode>manual</connectionMode>
 	<MSM>
 		<security>
 			<authEncryption>

--- a/SimpleWifi/ProfileXML/WPA2-Enterprise-TLS.xml
+++ b/SimpleWifi/ProfileXML/WPA2-Enterprise-TLS.xml
@@ -7,7 +7,7 @@
 		</SSID>
 	</SSIDConfig>
 	<connectionType>ESS</connectionType>
-	<connectionMode>auto</connectionMode>
+	<connectionMode>manual</connectionMode>
 	<autoSwitch>false</autoSwitch>
 	<MSM>
 		<security>

--- a/SimpleWifi/ProfileXML/WPA2-PSK.xml
+++ b/SimpleWifi/ProfileXML/WPA2-PSK.xml
@@ -7,7 +7,7 @@
 		</SSID>
 	</SSIDConfig>
 	<connectionType>ESS</connectionType>
-	<connectionMode>auto</connectionMode>
+	<connectionMode>manual</connectionMode>
 	<autoSwitch>false</autoSwitch>
 	<MSM>
 		<security>

--- a/SimpleWifi/SimpleWifi.csproj
+++ b/SimpleWifi/SimpleWifi.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SimpleWifi</RootNamespace>
     <AssemblyName>SimpleWifi</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <UpgradeBackupLocation>

--- a/SimpleWifi/Win32/Helpers/WlanHelpers.cs
+++ b/SimpleWifi/Win32/Helpers/WlanHelpers.cs
@@ -7,41 +7,41 @@ using System.Text;
 
 namespace SimpleWifi.Win32.Helpers
 {
-	internal static class WlanHelpers
-	{
-		internal static WlanConnectionNotificationData? ParseWlanConnectionNotification(ref WlanNotificationData notifyData)
-		{
-			int expectedSize = Marshal.SizeOf(typeof(WlanConnectionNotificationData));
-			if (notifyData.dataSize < expectedSize)
-				return null;
+    internal static class WlanHelpers
+    {
+        internal static WlanConnectionNotificationData? ParseWlanConnectionNotification(ref WlanNotificationData notifyData)
+        {
+            int expectedSize = Marshal.SizeOf(typeof(WlanConnectionNotificationData));
+            if (notifyData.dataSize < expectedSize)
+                return null;
 
-			WlanConnectionNotificationData connNotifyData = (WlanConnectionNotificationData)Marshal.PtrToStructure(notifyData.dataPtr, typeof(WlanConnectionNotificationData));
+            WlanConnectionNotificationData connNotifyData = (WlanConnectionNotificationData)Marshal.PtrToStructure(notifyData.dataPtr, typeof(WlanConnectionNotificationData));
 
-			if (connNotifyData.wlanReasonCode == WlanReasonCode.Success)
-			{
-				long profileXmlPtrValue = notifyData.dataPtr.ToInt64() + Marshal.OffsetOf(typeof(WlanConnectionNotificationData), "profileXml").ToInt64();
-				connNotifyData.profileXml = Marshal.PtrToStringUni(new IntPtr(profileXmlPtrValue));
-			}
+            if (connNotifyData.wlanReasonCode == WlanReasonCode.Success)
+            {
+                long profileXmlPtrValue = notifyData.dataPtr.ToInt64() + Marshal.OffsetOf(typeof(WlanConnectionNotificationData), "profileXml").ToInt64();
+                connNotifyData.profileXml = Marshal.PtrToStringUni(new IntPtr(profileXmlPtrValue));
+            }
 
-			return connNotifyData;
-		}
+            return connNotifyData;
+        }
 
-		/// <summary>
-		/// Gets a string that describes a specified reason code. NOTE: Not used!
-		/// </summary>
-		/// <param name="reasonCode">The reason code.</param>
-		/// <returns>The string.</returns>
-		internal static string GetStringForReasonCode(WlanReasonCode reasonCode)
-		{
-			StringBuilder sb = new StringBuilder(1024); // the 1024 size here is arbitrary; the WlanReasonCodeToString docs fail to specify a recommended size
+        /// <summary>
+        /// Gets a string that describes a specified reason code. NOTE: Not used!
+        /// </summary>
+        /// <param name="reasonCode">The reason code.</param>
+        /// <returns>The string.</returns>
+        internal static string GetStringForReasonCode(WlanReasonCode reasonCode)
+        {
+            StringBuilder sb = new StringBuilder(1024); // the 1024 size here is arbitrary; the WlanReasonCodeToString docs fail to specify a recommended size
 
-			if (WlanInterop.WlanReasonCodeToString(reasonCode, sb.Capacity, sb, IntPtr.Zero) != 0)
-			{
-				sb.Clear(); // Not sure if we get junk in the stringbuilder buffer from WlanReasonCodeToString, clearing it to be sure. 
-				sb.Append("Failed to retrieve reason code, probably too small buffer.");
-			}
+            if (WlanInterop.WlanReasonCodeToString(reasonCode, sb.Capacity, sb, IntPtr.Zero) != 0)
+            {
+                sb.Length = 0; // Not sure if we get junk in the stringbuilder buffer from WlanReasonCodeToString, clearing it to be sure. 
+                sb.Append("Failed to retrieve reason code, probably too small buffer.");
+            }
 
-			return sb.ToString();
-		}
-	}
+            return sb.ToString();
+        }
+    }
 }


### PR DESCRIPTION
I needed this project on my 3.5 project. The only thing that was 4.0 was
the StringBuilder.Clear() that doesn't exist in 3.5. I've change it to
sb.Lenght=0; to make it work.
