### PR TITLE
AccessPoint.IsConnected: only if actually connected

### DIFF
--- a/SimpleWifi/AccessPoint.cs
+++ b/SimpleWifi/AccessPoint.cs
@@ -70,7 +70,7 @@ namespace SimpleWifi
 				try
 				{
 					var a = _interface.CurrentConnection; // This prop throws exception if not connected, which forces me to this try catch. Refactor plix.
-					return a.profileName == _network.profileName;
+					return a.profileName == _network.profileName && a.isState == WlanInterfaceState.Connected;
 				}
 				catch
 				{


### PR DESCRIPTION
AccessPoint.IsConnected return true if the current connection profile name is identical to the access point name.

But the connection can be in Association or Discovering step, which does not allow to use effectively the connection.

I propose IsConnected returs true only if current connection's name is the same and connection state is Connected.
