### PR TITLE
Fix connection to access points containing Latin diacritic characters in their SSID name

### DIFF
--- a/SimpleWifi/ProfileFactory.cs
+++ b/SimpleWifi/ProfileFactory.cs
@@ -18,8 +18,11 @@ namespace SimpleWifi
 		{
 			string profile	= string.Empty;
 			string template = string.Empty;
-			string name		= Encoding.ASCII.GetString(network.dot11Ssid.SSID, 0, (int)network.dot11Ssid.SSIDLength);
-			string hex		= GetHexString(network.dot11Ssid.SSID);	
+			string name		= Encoding.UTF8.GetString(network.dot11Ssid.SSID, 0, (int)network.dot11Ssid.SSIDLength);
+			string hex		= GetHexString(network.dot11Ssid.SSID);
+
+			name = System.Security.SecurityElement.Escape(name);
+			password = System.Security.SecurityElement.Escape(password);			
 
 			var authAlgo = network.dot11DefaultAuthAlgorithm;
 
@@ -37,12 +40,12 @@ namespace SimpleWifi
 					if (authAlgo == Dot11AuthAlgorithm.RSNA)
 					{
 						template = GetTemplate("WPA2-Enterprise-PEAP-MSCHAPv2");
-						profile = string.Format(template, name);
+						profile = string.Format(template, name, hex);
 					}
 					else // PSK
 					{
 						template = GetTemplate("WPA2-PSK");
-						profile = string.Format(template, name, password);
+						profile = string.Format(template, name, hex, password);
 					}
 					break;
 				case Dot11CipherAlgorithm.TKIP:
@@ -50,12 +53,12 @@ namespace SimpleWifi
 					if (authAlgo == Dot11AuthAlgorithm.RSNA)
 					{
 						template = GetTemplate("WPA-Enterprise-PEAP-MSCHAPv2");
-						profile = string.Format(template, name);
+						profile = string.Format(template, name, hex);
 					}
 					else // PSK
 					{
 						template = GetTemplate("WPA-PSK");
-						profile = string.Format(template, name, password);
+						profile = string.Format(template, name, hex, password);
 					}
 
 					break;			

--- a/SimpleWifi/ProfileXML/OPEN.xml
+++ b/SimpleWifi/ProfileXML/OPEN.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WLANProfile xmlns="http://www.microsoft.com/networking/WLAN/profile/v1">
 	<name>{0}</name>
 	<SSIDConfig>

--- a/SimpleWifi/ProfileXML/WEP.xml
+++ b/SimpleWifi/ProfileXML/WEP.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WLANProfile xmlns="http://www.microsoft.com/networking/WLAN/profile/v1">
 	<name>{0}</name>
 	<SSIDConfig>

--- a/SimpleWifi/ProfileXML/WPA-Enterprise-PEAP-MSCHAPv2.xml
+++ b/SimpleWifi/ProfileXML/WPA-Enterprise-PEAP-MSCHAPv2.xml
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="us-ascii"?>
+<?xml version="1.0" encoding="utf-8"?>
 <WLANProfile xmlns="http://www.microsoft.com/networking/WLAN/profile/v1">
 	<name>{0}</name>
 	<SSIDConfig>
 		<SSID>
+      <hex>{1}</hex>
 			<name>{0}</name>
 		</SSID>
 	</SSIDConfig>

--- a/SimpleWifi/ProfileXML/WPA-Enterprise-TLS.xml
+++ b/SimpleWifi/ProfileXML/WPA-Enterprise-TLS.xml
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="us-ascii"?>
+<?xml version="1.0" encoding="utf-8"?>
 <WLANProfile xmlns="http://www.microsoft.com/networking/WLAN/profile/v1">
 	<name>{0}</name>
 	<SSIDConfig>
 		<SSID>
+      <hex>{1}</hex>
 			<name>{0}</name>
 		</SSID>
 		<nonBroadcast>false</nonBroadcast>

--- a/SimpleWifi/ProfileXML/WPA-PSK.xml
+++ b/SimpleWifi/ProfileXML/WPA-PSK.xml
@@ -1,9 +1,10 @@
-<?xml version="1.0" encoding="us-ascii"?>
+<?xml version="1.0" encoding="utf-8"?>
 <WLANProfile xmlns="http://www.microsoft.com/networking/WLAN/profile/v1">
 	<name>{0}</name>
 	<SSIDConfig>
 		<SSID>
-			<name>{0}</name>
+      <hex>{1}</hex>
+      <name>{0}</name>
 		</SSID>
 	</SSIDConfig>
 	<connectionType>ESS</connectionType>
@@ -19,7 +20,7 @@
 			<sharedKey>
 				<keyType>passPhrase</keyType>
 				<protected>false</protected>
-				<keyMaterial>{1}</keyMaterial>
+				<keyMaterial>{2}</keyMaterial>
 			</sharedKey>
 		</security>
 	</MSM>

--- a/SimpleWifi/ProfileXML/WPA2-Enterprise-PEAP-MSCHAPv2.xml
+++ b/SimpleWifi/ProfileXML/WPA2-Enterprise-PEAP-MSCHAPv2.xml
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="us-ascii"?>
+<?xml version="1.0" encoding="utf-8"?>
 <WLANProfile xmlns="http://www.microsoft.com/networking/WLAN/profile/v1">
 	<name>{0}</name>
 	<SSIDConfig>
 		<SSID>
+      <hex>{1}</hex>
 			<name>{0}</name>
 		</SSID>
 	</SSIDConfig>

--- a/SimpleWifi/ProfileXML/WPA2-Enterprise-TLS.xml
+++ b/SimpleWifi/ProfileXML/WPA2-Enterprise-TLS.xml
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="us-ascii"?>
+<?xml version="1.0" encoding="utf-8"?>
 <WLANProfile xmlns="http://www.microsoft.com/networking/WLAN/profile/v1">
 	<name>{0}</name>
 	<SSIDConfig>
 		<SSID>
+      <hex>{1}</hex>
 			<name>{0}</name>
 		</SSID>
 	</SSIDConfig>

--- a/SimpleWifi/ProfileXML/WPA2-PSK.xml
+++ b/SimpleWifi/ProfileXML/WPA2-PSK.xml
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="us-ascii"?>
+<?xml version="1.0" encoding="utf-8"?>
 <WLANProfile xmlns="http://www.microsoft.com/networking/WLAN/profile/v1">
 	<name>{0}</name>
 	<SSIDConfig>
 		<SSID>
+      <hex>{1}</hex>
 			<name>{0}</name>
 		</SSID>
 	</SSIDConfig>
@@ -19,7 +20,7 @@
 			<sharedKey>
 				<keyType>passPhrase</keyType>
 				<protected>false</protected>
-				<keyMaterial>{1}</keyMaterial>
+				<keyMaterial>{2}</keyMaterial>
 			</sharedKey>
 		</security>
 	</MSM>


### PR DESCRIPTION
SSIDs names now processed as UTF8 to preserve accented/diacritic/unicode characters.
The name is also now escaped before output to the XML profile.

The WLAN profile XML templates have been updated to UFT8 format and to include the hex ssid.
This was required for the connection to work with accented/diacritic/unicode characters.

# Conflicts:
#	SimpleWifi/ProfileFactory.cs